### PR TITLE
Update to `free-style@2.0.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,20 +26,22 @@ npm install react-free-style --save
 ## Usage
 
 ```js
+import { create, wrap, StyleElement } from 'react-free-style'
+
 // Create a style instance for the component.
-var Style = require('react-free-style').create()
+const Style = create()
 
 // Register some styles.
-var TEXT_STYLE = Style.registerStyle({
+var textStyle = Style.registerStyle({
   backgroundColor: 'red'
 })
 
-// Create a React component (also rendering the `Style.Element` component).
+// Create a React component (which is also rendering the `StyleElement` component).
 var App = React.createClass({
 
   render: function () {
     return (
-      <div className={TEXT_STYLE}>
+      <div className={textStyle}>
         Hello world!
 
         <Style.Element />
@@ -49,14 +51,14 @@ var App = React.createClass({
 
 })
 
-// Wrap `App` to create a component with style merging.
-App = Style.component(App)
+// Wrap `App` with the styles to automatically render CSS changes.
+App = wrap(App, Style)
 
 // Render to the document.
 React.render(<App />, document.body)
 ```
 
-**Note:** You should render `Style.Element` at the root level of your application, but it must be a child of `Style.component()`. I recommend rendering it last so it receives all styles after the first render (required for isomorphic applications).
+**Note:** You should render `StyleElement` once at the root level of your application, but it must be a child of `wrap()`. I recommend rendering it last so it receives all styles after the first render, which is useful for isomorphic applications.
 
 ### Styles
 
@@ -94,6 +96,35 @@ Style.registerRule('@media print', {
     color: 'red'
   }
 })
+```
+
+### Dynamical Styles, Keyframes and Rules
+
+```js
+class MyComponent extends React.Component {
+
+  static contextTypes = {
+    freeStyle: React.PropTypes.object.isRequired
+  }
+
+  componentWillMount () {
+    // Also has `registerKeyframes` and `registerRule` methods.
+    this.inlineClassName = this.context.freeStyle.registerStyle(this.props.style)
+  }
+
+  render () {
+    return React.createElement(
+      'button',
+      {
+        className: this.inlineClassName
+      },
+      this.props.children
+    )
+  }
+
+}
+
+export default wrap(MyComponent)
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "lint": "# TODO",
+    "lint": "tslint \"src/**/*.ts\"",
     "build": "rm -rf dist/ && tsc",
     "test-spec": "mocha dist/**/*.spec.js -R spec --bail",
     "test-cov": "istanbul cover -x dist/**/*.spec.js node_modules/mocha/bin/_mocha -- dist/**/*.spec.js -R spec --bail",
@@ -41,10 +41,12 @@
     "ntypescript": "^1.201508100803.1",
     "react": "^15.0.2",
     "react-dom": "^15.0.2",
+    "tslint": "^3.15.1",
+    "tslint-config-standard": "^1.5.0",
     "typescript": "^2.0.3",
     "typings": "^1.3.0"
   },
   "dependencies": {
-    "free-style": "^1.0.0"
+    "free-style": "^2.0.0"
   }
 }

--- a/src/react-free-style.spec.ts
+++ b/src/react-free-style.spec.ts
@@ -3,152 +3,166 @@
 import { expect } from 'chai'
 import * as React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { create, ReactFreeStyle, FreeStyle } from './react-free-style'
+import { create, wrap, StyleElement, FreeStyle, ReactFreeStyleContext } from './react-free-style'
 
 describe('react free style', function () {
-  let Style: ReactFreeStyle
+  let Style: FreeStyle.FreeStyle
 
   beforeEach(function () {
     Style = create()
   })
 
   it('should render the main example', function () {
-    const TEXT_STYLE = Style.registerStyle({
+    const textStyle = Style.registerStyle({
       backgroundColor: 'red'
     })
 
-    const App = Style.component(React.createClass({
+    const Component = React.createClass({
 
       displayName: 'App',
 
-      render: function () {
+      render () {
         return React.createElement(
           'div',
-          { className: TEXT_STYLE },
+          { className: textStyle },
           'Hello world!',
-          React.createElement(Style.Element)
+          React.createElement(StyleElement)
         )
       }
 
-    }))
+    })
+
+    const App = wrap(Component, Style)
 
     expect(renderToStaticMarkup(React.createElement(App))).to.equal(
-      '<div class="' + TEXT_STYLE + '">' +
+      '<div class="' + textStyle + '">' +
       'Hello world!' +
-      '<style>.' + TEXT_STYLE + '{background-color:red}</style>' +
+      '<style>.' + textStyle + '{background-color:red}</style>' +
       '</div>'
     )
   })
 
   it('should render the example dynamic styles', function () {
-    let inlineStyle: FreeStyle.Style
+    let inlineStyle = ''
 
-    const BUTTON_STYLE = Style.registerStyle({
+    const buttonStyle = Style.registerStyle({
       backgroundColor: 'red',
       padding: 10
     })
 
-    const ButtonComponent = React.createClass<{ style: any }, {}>({
+    class ButtonComponent extends React.Component<{ style: any }, {}> {
 
-      contextTypes: {
+      static contextTypes = {
         freeStyle: React.PropTypes.object.isRequired
-      },
+      }
 
-      componentWillMount: function () {
-        inlineStyle = this.inlineStyle = this.context.freeStyle.registerStyle(this.props.style)
-      },
+      inlineStyle: string
 
-      render: function () {
-        return React.createElement(
+      componentWillMount () {
+        const style = (this.context as ReactFreeStyleContext).freeStyle.registerStyle(this.props.style)
+
+        inlineStyle = this.inlineStyle = style
+      }
+
+      render () {
+        return React.createElement<{ className: string }, HTMLButtonElement>(
           'button',
           {
-            className: Style.join(this.inlineStyle, BUTTON_STYLE)
+            className: `${this.inlineStyle} ${buttonStyle}`
           },
-          this.props.children
+          this.props.children as any
         )
       }
 
-    })
+    }
 
-    const App = Style.component(React.createClass({
+    const Component = React.createClass({
 
-      render: function () {
+      render () {
         return React.createElement(
           'div',
-          null,
+          {},
           React.createElement(
             ButtonComponent,
             { style: { color: 'blue'} },
             'Hello world!'
           ),
-          React.createElement(Style.Element)
+          React.createElement(StyleElement)
         )
       }
 
-    }))
+    })
+
+    const App = wrap(Component, Style)
 
     expect(renderToStaticMarkup(React.createElement(App))).to.equal(
       '<div>' +
-      '<button class="' + inlineStyle + ' ' + BUTTON_STYLE + '">Hello world!</button>' +
-      '<style>.' + BUTTON_STYLE + '{background-color:red;padding:10px}.' + inlineStyle + '{color:blue}</style>' +
+      '<button class="' + inlineStyle + ' ' + buttonStyle + '">Hello world!</button>' +
+      '<style>.' + buttonStyle + '{background-color:red;padding:10px}.' + inlineStyle + '{color:blue}</style>' +
       '</div>'
     )
   })
 
-  it('should work with children', function () {
-    const ChildStyle = create()
+  it('should work with nested styles', function () {
+    const NestedStyle = create()
 
-    const APP_STYLE = Style.registerStyle({
+    const appStyle = Style.registerStyle({
       color: 'blue'
     })
 
-    const BUTTON_STYLE = ChildStyle.registerStyle({
+    const buttonStyle = NestedStyle.registerStyle({
       backgroundColor: 'red'
     })
 
-    const Button = ChildStyle.component(React.createClass({
+    const Button = wrap(
+      React.createClass({
 
-      render: function () {
-        return React.createElement(
-          'button',
-          { className: BUTTON_STYLE },
-          'Hello world!'
-        )
-      }
+        render () {
+          return React.createElement(
+            'button',
+            { className: buttonStyle },
+            'Hello world!'
+          )
+        }
 
-    }))
+      }),
+      NestedStyle
+    )
 
-    const Child = ChildStyle.component(React.createClass({
+    const Child = React.createClass({
 
-      render: function () {
+      render () {
         return React.createElement(
           'div',
-          null,
+          {},
           React.createElement(Button)
         )
       }
 
-    }))
+    })
 
-    const App = Style.component(React.createClass({
+    const App = wrap(
+      React.createClass({
 
-      render: function () {
-        return React.createElement(
-          'div',
-          { className: APP_STYLE },
-          React.createElement(Child),
-          React.createElement(Style.Element)
-        )
-      }
+        render () {
+          return React.createElement(
+            'div',
+            { className: appStyle },
+            React.createElement(Child),
+            React.createElement(StyleElement)
+          )
+        }
 
-    }))
+      }),
+      Style
+    )
 
     expect(renderToStaticMarkup(React.createElement(App))).to.equal(
-      '<div class="' + APP_STYLE + '">' +
+      '<div class="' + appStyle + '">' +
       '<div>' +
-      '<button class="' + BUTTON_STYLE + '">Hello world!</button>' +
+      '<button class="' + buttonStyle + '">Hello world!</button>' +
       '</div>' +
-      '<style>.' + APP_STYLE + '{color:blue}.' + BUTTON_STYLE + '{background-color:red}</style>' +
+      '<style>.' + appStyle + '{color:blue}.' + buttonStyle + '{background-color:red}</style>' +
       '</div>'
     )
   })

--- a/src/react-free-style.ts
+++ b/src/react-free-style.ts
@@ -1,111 +1,196 @@
 import React = require('react')
 import ReactCurrentOwner = require('react/lib/ReactCurrentOwner')
-export import FreeStyle = require('free-style')
+import * as FreeStyle from 'free-style'
 
 /**
- * Create a specialized free style instance.
+ * Re-export the `free-style` module.
  */
-export class ReactFreeStyle extends FreeStyle.FreeStyle {
+export { FreeStyle }
 
-  /**
-   * Expose the `StyleElement` for use.
-   */
-  Element = StyleElement
-
-  /**
-   * Create a React component that inherits from a user component. This is
-   * required for methods on the user component to continue working once
-   * wrapped with the style functionality.
-   */
-  component<T> (Component: React.ComponentClass<T> | React.StatelessComponent<T>): React.ComponentClass<T> {
-    const freeStyle = this
-    const displayName = (Component as any).displayName || (Component as any).name
-
-    return class FreeStyleComponent extends React.Component <T, any> {
-      _freeStyle = freeStyle
-      _parentFreeStyle = (this.context as any).freeStyle || new ReactFreeStyle()
-
-      static displayName = `FreeStyleComponent${displayName ? `<${displayName}>` : ''}`
-
-      static contextTypes: React.ValidationMap<any> = {
-        freeStyle: React.PropTypes.object
-      }
-
-      static childContextTypes: React.ValidationMap<any> = {
-        freeStyle: React.PropTypes.object.isRequired
-      }
-
-      getChildContext () {
-        return {
-          freeStyle: this._parentFreeStyle
-        }
-      }
-
-      componentWillUpdate () {
-        // Hook into component updates to keep styles in sync over hot code
-        // reloads. This works great with React Hot Loader!
-        if (this._freeStyle.id !== freeStyle.id) {
-          this._parentFreeStyle.unmerge(this._freeStyle)
-          this._parentFreeStyle.merge(freeStyle)
-          this._freeStyle = freeStyle
-        }
-      }
-
-      componentWillMount () {
-        this._parentFreeStyle.merge(this._freeStyle)
-      }
-
-      componentWillUnmount () {
-        this._parentFreeStyle.unmerge(this._freeStyle)
-      }
-
-      render () {
-        return React.createElement(Component, this.props)
-      }
-
-    }
-  }
-
+/**
+ * The context used with `react-free-style`.
+ */
+export interface ReactFreeStyleContext {
+  freeStyle: StyleContext
+  rootFreeStyle: RootStyleContext
 }
 
 /**
- * Create the <style /> element.
+ * Wrap a React component to automatically attach and detach styles.
+ */
+export function wrap <T> (
+  Component: React.ComponentClass<T> | React.StatelessComponent<T>,
+  ...styles: FreeStyle.FreeStyle[]
+): React.ComponentClass<T> {
+  const displayName = Component.displayName || (Component as any).name
+  const componentStyles = styles.map(x => x.clone())
+
+  return class StyleComponent <T> extends React.Component <T, any> {
+
+    static displayName = `FreeStyleComponent${displayName ? `<${displayName}>` : ''}`
+
+    static contextTypes: React.ValidationMap<any> = {
+      freeStyle: React.PropTypes.object,
+      rootFreeStyle: React.PropTypes.object
+    }
+
+    static childContextTypes: React.ValidationMap<any> = {
+      freeStyle: React.PropTypes.object.isRequired,
+      rootFreeStyle: React.PropTypes.object.isRequired
+    }
+
+    _rootFreeStyle = (this.context as ReactFreeStyleContext).rootFreeStyle || new RootStyleContext()
+    _freeStyle = new StyleContext(this._rootFreeStyle)
+
+    constructor (public childProps: T, context: any) {
+      super(childProps, context)
+    }
+
+    getChildContext () {
+      return {
+        freeStyle: this._freeStyle,
+        rootFreeStyle: this._rootFreeStyle
+      }
+    }
+
+    componentWillMount () {
+      for (const style of componentStyles) {
+        this._rootFreeStyle.style.merge(style)
+      }
+
+      this._freeStyle.mount()
+    }
+
+    componentWillUnmount () {
+      for (const style of componentStyles) {
+        this._rootFreeStyle.style.unmerge(style)
+      }
+
+      this._freeStyle.unmount()
+    }
+
+    render () {
+      return React.createElement(Component, this.childProps as any)
+    }
+
+  }
+}
+
+/**
+ * Create the `<style />` element.
  */
 export class StyleElement extends React.Component<{}, {}> {
 
   static displayName = 'Style'
 
   static contextTypes: React.ValidationMap<any> = {
-    freeStyle: React.PropTypes.object.isRequired
+    rootFreeStyle: React.PropTypes.object.isRequired
   }
 
   onChange = () => {
     if (ReactCurrentOwner.current != null) {
-      console.warn('React Free Style: Inline styles can not be registered during `render`. If you want to register styles dynamically, you should use `componentWillMount` and `componentWillUnmount` to manage styles (remember to use `FreeStyle#get(id)` and `FreeStyle#remove(instance)` to remove styles after use)')
+      console.warn(
+        'React Free Style: Inline styles can not be registered during `render`. ' +
+        'If you want to style dynamically, use `componentWillMount` instead.'
+      )
     }
 
     return this.forceUpdate()
   }
 
   componentWillMount () {
-    ;(this.context as any).freeStyle.addChangeListener(this.onChange)
+    ;(this.context as ReactFreeStyleContext).rootFreeStyle.addChangeListener(this.onChange)
   }
 
   componentWillUnmount () {
-    ;(this.context as any).freeStyle.removeChangeListener(this.onChange)
+    ;(this.context as ReactFreeStyleContext).rootFreeStyle.removeChangeListener(this.onChange)
   }
 
   render () {
-    return React.createElement('style', {
-      dangerouslySetInnerHTML: { __html: (this.context as any).freeStyle.getStyles() }
-    })
+    const style = (this.context as ReactFreeStyleContext).rootFreeStyle.style.getStyles()
+
+    return React.createElement('style', {}, style)
   }
 
 }
 
 /**
- * Create a React Free Style instance.
+ * Create a class for passing down the style context.
  */
-export function create () {
-  return new ReactFreeStyle()
+export class RootStyleContext {
+
+  listeners: Array<() => void> = []
+  style = create()
+  prevChangeId = this.style.changeId
+
+  changed () {
+    if (this.style.changeId !== this.prevChangeId) {
+      this.prevChangeId = this.style.changeId
+      this.listeners.forEach(x => x())
+    }
+  }
+
+  addChangeListener (cb: () => void) {
+    this.listeners.push(cb)
+  }
+
+  removeChangeListener (cb: () => void) {
+    const indexOf = this.listeners.indexOf(cb)
+
+    if (indexOf > -1) {
+      this.listeners.splice(indexOf, 1)
+    }
+  }
+
+}
+
+/**
+ * The style context object is passed to the child context to allow dynamic styles.
+ */
+export class StyleContext {
+
+  style = create()
+
+  constructor (public root: RootStyleContext) {}
+
+  registerStyle (styles: FreeStyle.UserStyles, displayName?: string) {
+    this.root.style.unmerge(this.style)
+    const className = this.style.registerStyle(styles, displayName)
+    this.root.style.merge(this.style)
+    this.root.changed()
+    return className
+  }
+
+  registerKeyframes (styles: FreeStyle.UserStyles, displayName?: string) {
+    this.root.style.unmerge(this.style)
+    const keyframes = this.style.registerKeyframes(styles, displayName)
+    this.root.style.merge(this.style)
+    this.root.changed()
+    return keyframes
+  }
+
+  registerRule (rule: string, styles: FreeStyle.UserStyles) {
+    this.root.style.unmerge(this.style)
+    this.style.registerRule(rule, styles)
+    this.root.style.merge(this.style)
+    this.root.changed()
+  }
+
+  mount () {
+    this.root.style.merge(this.style)
+    this.root.changed()
+  }
+
+  unmount () {
+    this.root.style.unmerge(this.style)
+    this.root.changed()
+  }
+
+}
+
+/**
+ * Create a Free Style instance.
+ */
+export function create (hash?: FreeStyle.HashFunction, debug?: boolean) {
+  return FreeStyle.create(hash, debug)
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "commonjs",
     "declaration": true,
     "noImplicitAny": true,
+    "strictNullChecks": true,
     "removeComments": false,
     "sourceMap": true,
     "inlineSources": true

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "tslint-config-standard"
+}

--- a/typings.json
+++ b/typings.json
@@ -1,14 +1,9 @@
 {
-  "globalDependencies": {
-    "chai": "github:DefinitelyTyped/DefinitelyTyped/chai/chai.d.ts#575d70adcad0086ec8c6f672a5eb569a4689486c",
-    "mocha": "github:DefinitelyTyped/DefinitelyTyped/mocha/mocha.d.ts#575d70adcad0086ec8c6f672a5eb569a4689486c"
-  },
-  "dependencies": {
-    "free-style": "npm:free-style"
-  },
   "globalDevDependencies": {
-    "react": "github:DefinitelyTyped/DefinitelyTyped/react/react.d.ts#f9117cf5dd3420b4fcb4342bf287945695a953a4",
-    "react-dom": "github:DefinitelyTyped/DefinitelyTyped/react/react-dom.d.ts#b9642fb8ac07f7164dc643ddd1fa99b58ae9be8b",
+    "chai": "registry:dt/chai#3.4.0+20160601211834",
+    "mocha": "registry:dt/mocha#2.2.5+20160720003353",
+    "react": "registry:dt/react#0.14.0+20161008064207",
+    "react-dom": "registry:dt/react-dom#0.14.0+20160412154040",
     "react-lib-current-owner": "file:custom_typings/react.d.ts"
   }
 }


### PR DESCRIPTION
* Moved away from class extension - directly exporting `StyleElement` and `wrap` now
* Moved to two independent `freeStyle` context objects - `freeStyle` and `rootFreeStyle` (should never need to access `root` directly)